### PR TITLE
fix: standardize useUser (named export + profile.role), wire into Acc…

### DIFF
--- a/components/AccountShell.tsx
+++ b/components/AccountShell.tsx
@@ -1,11 +1,13 @@
 // components/AccountShell.tsx
-import { ReactNode } from 'react'
 import AccountSidebar from './AccountSidebar'
+import type { ReactNode } from 'react'
 
 type Props = {
   title?: string
   actions?: ReactNode
   children: ReactNode
+  // we *accept* admin but we don't need it anymore; keep it optional to avoid breakage
+  admin?: boolean
 }
 
 export default function AccountShell({ title, actions, children }: Props) {
@@ -16,7 +18,7 @@ export default function AccountShell({ title, actions, children }: Props) {
         {(title || actions) && (
           <div className="flex items-center justify-between">
             {title ? <h1 className="text-2xl font-bold">{title}</h1> : <div />}
-            {actions ? <div>{actions}</div> : null}
+            {actions ? <div className="flex gap-2">{actions}</div> : null}
           </div>
         )}
         {children}

--- a/components/AccountSidebar.tsx
+++ b/components/AccountSidebar.tsx
@@ -1,57 +1,45 @@
 // components/AccountSidebar.tsx
-import { useEffect, useState } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { supabase } from '../lib/supabaseClient'
-import { useUser } from '../lib/useUser' // named export
+import { useUser } from '../lib/useUser'
 
 type Item = { href: string; label: string }
 
 export default function AccountSidebar() {
   const router = useRouter()
-  const { user } = useUser()
-  const [isAdmin, setIsAdmin] = useState(false)
+  const { user, profile } = useUser()
+  const isAdmin = profile?.role === 'admin'
 
-  // Look up the user's role (client-side, lightweight)
-  useEffect(() => {
-    let cancelled = false
-    async function loadRole() {
-      if (!user) { setIsAdmin(false); return }
-      const { data, error } = await supabase
-        .from('profiles')
-        .select('role')
-        .eq('id', user.id)
-        .maybeSingle()
-      if (!cancelled) setIsAdmin(!!data && data.role === 'admin')
-      if (error) console.warn('role lookup failed:', error.message)
-    }
-    loadRole()
-    return () => { cancelled = true }
-  }, [user])
-
-  const items: Item[] = [
+  const common: Item[] = [
     { href: '/account', label: 'Account home' },
-    { href: '/account/billing', label: 'Billing & entitlements' },
     { href: '/account/brand', label: 'My brand' },
-    { href: '/account/products', label: 'Products (test)' },
-    { href: '/shop', label: 'Shop' },
-    // Admin link only for admins
-    ...(isAdmin ? [{ href: '/admin', label: 'Admin' } as Item] : []),
+    { href: '/account/products', label: 'My products' },
+    { href: '/account/billing', label: 'Billing' },
+    { href: '/services', label: 'HEMPIN services' },
   ]
+
+  const adminOnly: Item[] = isAdmin
+    ? [
+        { href: '/admin', label: 'Admin dashboard' },
+        { href: '/admin/submissions', label: 'Pending submissions' },
+        { href: '/admin/payments', label: 'Payments' },
+      ]
+    : []
 
   async function handleLogout() {
     await supabase.auth.signOut()
-    router.replace('/auth/logout') // simple confirmation page
+    router.replace('/auth/logout')
   }
 
   return (
     <aside className="w-[230px] shrink-0 border-r border-white/10 p-4 space-y-4">
       <div className="text-xs opacity-70">
-        Signed in as<br />{user?.email ?? 'Guest'}
+        Signed in as<br />{user?.email ?? '—'}
       </div>
 
       <nav className="flex flex-col gap-2">
-        {items.map(i => (
+        {[...common, ...adminOnly].map((i) => (
           <Link key={i.href} href={i.href} className="hover:underline">
             {i.label}
           </Link>

--- a/lib/useUser.ts
+++ b/lib/useUser.ts
@@ -1,33 +1,71 @@
 // lib/useUser.ts
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import type { User, Session } from '@supabase/supabase-js'
 import { supabase } from './supabaseClient'
 
+type Profile = { role?: 'admin' | 'user' | string | null } | null
+
 export function useUser() {
-  const [session, setSession] = useState<Session | null>(null)
   const [user, setUser] = useState<User | null>(null)
+  const [session, setSession] = useState<Session | null>(null)
+  const [profile, setProfile] = useState<Profile>(null)
   const [loading, setLoading] = useState(true)
 
-  useEffect(() => {
-    let mounted = true
-    ;(async () => {
-      const { data } = await supabase.auth.getSession()
-      if (!mounted) return
-      setSession(data.session ?? null)
-      setUser(data.session?.user ?? null)
-      setLoading(false)
-    })()
+  // signOut helper
+  const signOut = useCallback(async () => {
+    await supabase.auth.signOut()
+  }, [])
 
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, sess) => {
-      setSession(sess)
-      setUser(sess?.user ?? null)
+  useEffect(() => {
+    let cancelled = false
+
+    const init = async () => {
+      try {
+        const { data } = await supabase.auth.getSession()
+        const s = data.session ?? null
+        const u = s?.user ?? null
+        if (cancelled) return
+        setSession(s)
+        setUser(u)
+
+        if (u) {
+          const { data: prof } = await supabase
+            .from('profiles')
+            .select('role')
+            .eq('id', u.id)
+            .maybeSingle()
+          if (!cancelled) setProfile(prof ?? { role: null })
+        } else {
+          setProfile(null)
+        }
+      } finally {
+        if (!cancelled) setLoading(false)
+      }
+    }
+
+    init()
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, newSession) => {
+      setSession(newSession)
+      setUser(newSession?.user ?? null)
+      // refetch profile when auth changes
+      if (newSession?.user) {
+        supabase
+          .from('profiles')
+          .select('role')
+          .eq('id', newSession.user.id)
+          .maybeSingle()
+          .then(({ data: prof }) => setProfile(prof ?? { role: null }))
+      } else {
+        setProfile(null)
+      }
     })
 
     return () => {
-      mounted = false
+      cancelled = true
       sub.subscription.unsubscribe()
     }
   }, [])
 
-  return { user, session, loading }
+  return { user, session, profile, loading, signOut }
 }

--- a/pages/auth/logout.tsx
+++ b/pages/auth/logout.tsx
@@ -1,0 +1,15 @@
+// pages/auth/logout.tsx
+import Link from 'next/link'
+
+export default function LoggedOut() {
+  return (
+    <main className="container max-w-lg mx-auto px-4 py-16 text-center space-y-4">
+      <h1 className="text-2xl font-bold">You’re logged out</h1>
+      <p className="opacity-80">Come back anytime.</p>
+      <div className="flex justify-center gap-3">
+        <Link href="/" className="btn btn-outline">Go to homepage</Link>
+        <Link href="/account" className="btn btn-primary">Sign in</Link>
+      </div>
+    </main>
+  )
+}


### PR DESCRIPTION
…ountSidebar; type AccountShell props; add /auth/logout

### Scope
- [ ] UI
- [ ] Functions
- [ ] DB/Supabase
- [ ] Docs/Config

### Routes touched
- (list routes and files)

### Screenshots / Logs
- (attach images or build excerpts)

### Test steps
1. ...
2. ...

### Checklist
- [ ] No secrets committed
- [ ] Builds locally or documented if offline
- [ ] Targets `staging`
- [ ] No UI/logic changes for this audit PR
