### PR TITLE
shell: wrap public pages once in _app; exclude /signin, /auth, /accou…

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,8 +8,14 @@ import { AccountRouteGuard } from '../lib/authGuard'
 export default function App({ Component, pageProps }: AppProps) {
   const router = useRouter()
   const isAccount = router.pathname.startsWith('/account')
-  const hidePublicShell =
-    router.pathname === '/signin' || router.pathname.startsWith('/auth/')
+
+  // Public shell only for true public pages (no auth, no account, no admin)
+  const shouldWrapWithPublicShell = !(
+    router.pathname === '/signin' ||
+    router.pathname.startsWith('/auth/') ||
+    router.pathname.startsWith('/account') ||
+    router.pathname.startsWith('/admin')
+  )
 
   const page = isAccount ? (
     <AccountRouteGuard>
@@ -19,8 +25,5 @@ export default function App({ Component, pageProps }: AppProps) {
     <Component {...pageProps} />
   )
 
-  // Don’t wrap signin/auth with the site shell (prevents double header/footer)
-  if (hidePublicShell) return page
-
-  return <PublicShell>{page}</PublicShell>
+  return shouldWrapWithPublicShell ? <PublicShell>{page}</PublicShell> : page
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,11 +1,11 @@
 // pages/index.tsx
 import Head from 'next/head'
 import Link from 'next/link'
-import PublicShell from '../components/PublicShell'
+
 
 export default function Home() {
   return (
-    <PublicShell>
+    
     
       <Head>
         <title>HEMPIN — Grow the Hemp Ecosystem</title>
@@ -176,7 +176,7 @@ export default function Home() {
 
         <SiteFooter />
       </div>
-    </PublicShell>
+  
   )
 }
 


### PR DESCRIPTION
…nt, /admin; remove duplicate shell from index

### Scope
- [ ] UI
- [ ] Functions
- [ ] DB/Supabase
- [ ] Docs/Config

### Routes touched
- (list routes and files)

### Screenshots / Logs
- (attach images or build excerpts)

### Test steps
1. ...
2. ...

### Checklist
- [ ] No secrets committed
- [ ] Builds locally or documented if offline
- [ ] Targets `staging`
- [ ] No UI/logic changes for this audit PR
