### PR TITLE
refactor(auth): centralized AuthSessionProvider in _app, remove globa…

### DIFF
--- a/components/auth/AuthSessionProvider.tsx
+++ b/components/auth/AuthSessionProvider.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import type { ReactNode } from 'react'
+import { supabase } from '../../lib/supabaseClient'
+
+type SessionState = {
+  loading: boolean
+  user: null | {
+    id: string
+    email?: string
+    [k: string]: any
+  }
+  // raw session if you need it later
+  session: any | null
+}
+
+const AuthCtx = createContext<SessionState>({ loading: true, user: null, session: null })
+
+export function useAuthSession() {
+  return useContext(AuthCtx)
+}
+
+export function AuthSessionProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<SessionState>({ loading: true, user: null, session: null })
+
+  useEffect(() => {
+    let alive = true
+
+    ;(async () => {
+      const { data, error } = await supabase.auth.getSession()
+      if (!alive) return
+      if (error) {
+        console.warn('auth getSession error:', error.message)
+        setState({ loading: false, user: null, session: null })
+      } else {
+        setState({ loading: false, user: data?.session?.user ?? null, session: data?.session ?? null })
+      }
+    })()
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_evt, session) => {
+      if (!alive) return
+      setState({ loading: false, user: session?.user ?? null, session: session ?? null })
+    })
+
+    return () => {
+      alive = false
+      sub?.subscription?.unsubscribe?.()
+    }
+  }, [])
+
+  const value = useMemo(() => state, [state.loading, state.user, state.session])
+
+  return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,29 +1,18 @@
-// pages/_app.tsx
 import type { AppProps } from 'next/app'
-import { useRouter } from 'next/router'
-import '../styles/globals.css'
-import PublicShell from '../components/PublicShell'
-import { AccountRouteGuard } from '../lib/authGuard'
+import Head from 'next/head'
+import '../styles/globals.css' // keep your global styles
+import { AuthSessionProvider } from '../components/auth/AuthSessionProvider'
 
-export default function App({ Component, pageProps }: AppProps) {
-  const router = useRouter()
-  const isAccount = router.pathname.startsWith('/account')
-
-  // Public shell only for true public pages (no auth, no account, no admin)
-  const shouldWrapWithPublicShell = !(
-    router.pathname === '/signin' ||
-    router.pathname.startsWith('/auth/') ||
-    router.pathname.startsWith('/account') ||
-    router.pathname.startsWith('/admin')
+export default function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <>
+      <Head>
+        <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5" />
+        <meta name="theme-color" content="#0b0f12" />
+      </Head>
+      <AuthSessionProvider>
+        <Component {...pageProps} />
+      </AuthSessionProvider>
+    </>
   )
-
-  const page = isAccount ? (
-    <AccountRouteGuard>
-      <Component {...pageProps} />
-    </AccountRouteGuard>
-  ) : (
-    <Component {...pageProps} />
-  )
-
-  return shouldWrapWithPublicShell ? <PublicShell>{page}</PublicShell> : page
 }


### PR DESCRIPTION
…l guard redirects

### Scope
- [ ] UI
- [ ] Functions
- [ ] DB/Supabase
- [ ] Docs/Config

### Routes touched
- (list routes and files)

### Screenshots / Logs
- (attach images or build excerpts)

### Test steps
1. ...
2. ...

### Checklist
- [ ] No secrets committed
- [ ] Builds locally or documented if offline
- [ ] Targets `staging`
- [ ] No UI/logic changes for this audit PR
