### PR TITLE
fix(auth): centralize AccountGuard in _app, replace useUser with useA…

### DIFF
--- a/components/SidebarLayout.tsx
+++ b/components/SidebarLayout.tsx
@@ -9,7 +9,7 @@ import React, {
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { supabase } from '../lib/supabaseClient'
-import { useUser } from '../lib/useUser'
+import { useAuth } from '../lib/authGuard'
 
 type Variant = 'account' | 'admin'
 type IconFC = (props: { className?: string }) => ReactElement
@@ -89,7 +89,7 @@ const NAV_ADMIN: NavItem[] = [
 
 export default function SidebarLayout({ variant, children }: Props) {
   const router = useRouter()
-  const { user, session } = useUser()
+  const { user, session } = useAuth()
 
   // NOTE: removed auto-redirect on !session to stop account/signin loop.
   // Pages render a sign-in card if needed; this layout stays neutral.

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,22 +2,43 @@
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import '../styles/globals.css'
+
 import { useRouter } from 'next/router'
+import { useEffect } from 'react'
 import { AccountGuard } from '../lib/authGuard'
+import { supabase } from '../lib/supabaseClient'
+
+/** Debug tracer: logs route changes and auth events to the console */
+function useDebugRouting() {
+  const router = useRouter()
+
+  useEffect(() => {
+    const onStart = (url: string) => console.debug('[route] ->', url)
+    router.events.on('routeChangeStart', onStart)
+    return () => router.events.off('routeChangeStart', onStart)
+  }, [router.events])
+
+  useEffect(() => {
+    console.debug('[auth] tracer mounted')
+    const { data } = supabase.auth.onAuthStateChange((evt, session) => {
+      console.debug('[auth]', evt, 'user=', session?.user?.id || null)
+    })
+    return () => data.subscription?.unsubscribe?.()
+  }, [])
+}
 
 export default function MyApp({ Component, pageProps }: AppProps) {
-  const router = useRouter()
-  const isAccountRoute = router.pathname.startsWith('/account')
-
-  const inner = <Component {...pageProps} />
-
+  useDebugRouting()
   return (
     <>
       <Head>
         <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=5" />
         <meta name="theme-color" content="#0b0f12" />
       </Head>
-      {isAccountRoute ? <AccountGuard>{inner}</AccountGuard> : inner}
+      {/* Wrap EVERYTHING so the context is always present */}
+      <AccountGuard>
+        <Component {...pageProps} />
+      </AccountGuard>
     </>
   )
 }


### PR DESCRIPTION
…uth in layout, add safety valve

### Scope
- [ ] UI
- [ ] Functions
- [ ] DB/Supabase
- [ ] Docs/Config

### Routes touched
- (list routes and files)

### Screenshots / Logs
- (attach images or build excerpts)

### Test steps
1. ...
2. ...

### Checklist
- [ ] No secrets committed
- [ ] Builds locally or documented if offline
- [ ] Targets `staging`
- [ ] No UI/logic changes for this audit PR
